### PR TITLE
feat: 현재 기상정보 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 /src/main/resources/config.yml
 /src/main/resources/application-local.yml
+
+/http/http-client.env.json

--- a/http/weather.http
+++ b/http/weather.http
@@ -1,0 +1,4 @@
+###
+//@no-log
+GET http://localhost:8080/api/v1/weather/current?
+    depth1 = 서울특별시

--- a/src/main/java/com/example/hyh/global/ClientLoggerRequestInterceptor.java
+++ b/src/main/java/com/example/hyh/global/ClientLoggerRequestInterceptor.java
@@ -1,0 +1,88 @@
+package com.example.hyh.global;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@Slf4j
+public class ClientLoggerRequestInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    public @NotNull ClientHttpResponse intercept(@NotNull HttpRequest request, byte @NotNull [] body, ClientHttpRequestExecution execution) throws IOException {
+        logRequest(request, body);
+        ClientHttpResponse response = execution.execute(request, body);
+        return logResponse(request, response);
+    }
+
+    private void logRequest(HttpRequest request, byte[] body) {
+        log.debug("Request: {} {}", request.getMethod(), request.getURI());
+        logHeaders(request.getHeaders());
+        if (body.length > 0) {
+            log.debug("Request body: {}", new String(body, StandardCharsets.UTF_8));
+        }
+    }
+
+    private ClientHttpResponse logResponse(HttpRequest request, ClientHttpResponse response) throws IOException {
+        log.debug("Response status: {}", response.getStatusCode());
+        logHeaders(response.getHeaders());
+
+        byte[] responseBody = response.getBody().readAllBytes();
+        if (responseBody.length > 0) {
+            log.debug("Response body: {}", new String(responseBody, StandardCharsets.UTF_8));
+        }
+
+        return new BufferingClientHttpResponseWrapper(response, responseBody);
+    }
+
+    private void logHeaders(HttpHeaders headers) {
+        headers.forEach((name, values) -> values.forEach(value -> log.info("{}={}", name, value)));
+    }
+
+    private static class BufferingClientHttpResponseWrapper implements ClientHttpResponse {
+        private final ClientHttpResponse response;
+        private final byte[] body;
+
+        public BufferingClientHttpResponseWrapper(ClientHttpResponse response, byte[] body) {
+            this.response = response;
+            this.body = body;
+        }
+
+        @Override
+        public @NotNull InputStream getBody() throws IOException {
+            return new ByteArrayInputStream(body);
+        }
+
+        @Override
+        public @NotNull HttpHeaders getHeaders() {
+            return response.getHeaders();
+        }
+
+        @Override
+        public @NotNull HttpStatusCode getStatusCode() throws IOException {
+            return response.getStatusCode();
+        }
+
+        @Override
+        public @NotNull String getStatusText() throws IOException {
+            return response.getStatusText();
+        }
+
+        @Override
+        public void close() {
+            response.close();
+        }
+    }
+}

--- a/src/main/java/com/example/hyh/global/Utils.java
+++ b/src/main/java/com/example/hyh/global/Utils.java
@@ -1,0 +1,12 @@
+package com.example.hyh.global;
+
+import org.jetbrains.annotations.Nullable;
+import org.springframework.util.StringUtils;
+
+public class Utils {
+
+    public static boolean isNumeric(@Nullable String str) {
+        return StringUtils.hasText(str) && str.chars().allMatch(Character::isDigit);
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/adapter/in/web/CurrentWeatherRestController.java
+++ b/src/main/java/com/example/hyh/weather/adapter/in/web/CurrentWeatherRestController.java
@@ -1,0 +1,48 @@
+package com.example.hyh.weather.adapter.in.web;
+
+import com.example.hyh.weather.application.port.in.GetCurrentWeatherCommand;
+import com.example.hyh.weather.application.port.in.GetCurrentWeatherUseCase;
+import com.example.hyh.weather.domain.CurrentWeather;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/weather/current")
+@RequiredArgsConstructor
+public class CurrentWeatherRestController {
+
+    private final GetCurrentWeatherUseCase getCurrentWeatherUseCase;
+
+    @GetMapping
+    CurrentWeatherResponse getCurrentWeather(@RequestParam String depth1,
+                                             @RequestParam(required = false) String depth2,
+                                             @RequestParam(required = false) String depth3) {
+        return CurrentWeatherResponse.fromCurrentWeather(
+                getCurrentWeatherUseCase.getCurrentWeather(new GetCurrentWeatherCommand(depth1, depth2, depth3))
+        );
+    }
+
+    record CurrentWeatherResponse(
+            String weatherCondition,
+            String humidityLevel,
+            String rainfallIntensity,
+            String airQualityPm10,
+            String airQualityPm25,
+            String uvIndex
+    ) {
+        public static CurrentWeatherResponse fromCurrentWeather(CurrentWeather currentWeather) {
+            return new CurrentWeatherResponse(
+                    currentWeather.weatherCondition().getDisplayName(),
+                    currentWeather.humidityLevel().getDisplayName(),
+                    currentWeather.rainfallIntensity().getDisplayName(),
+                    currentWeather.airQualityPm10().getDisplayName(),
+                    currentWeather.airQualityPm25().getDisplayName(),
+                    currentWeather.uvIndex().getDisplayName()
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/api/CurrentWeatherApiAdapter.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/api/CurrentWeatherApiAdapter.java
@@ -1,0 +1,160 @@
+package com.example.hyh.weather.adapter.out.api;
+
+import com.example.hyh.weather.adapter.out.api.response.AirPollutionApiResponse;
+import com.example.hyh.weather.adapter.out.api.response.LiveWeatherApiResponse;
+import com.example.hyh.weather.adapter.out.api.response.WeatherForecastApiResponse;
+import com.example.hyh.weather.application.port.out.FetchCurrentWeatherPort;
+import com.example.hyh.weather.application.port.out.LoadCoordinatesPort;
+import com.example.hyh.weather.domain.*;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentWeatherApiAdapter implements FetchCurrentWeatherPort {
+
+    private final LoadCoordinatesPort loadCoordinatesPort;
+
+    private final RestClient weatherForecastRestClient;
+    private final RestClient airPollutionRestClient;
+    private final RestClient liveWeatherRestClient;
+
+    private final int PAGE_NO = 1;
+    private final int NUM_OF_ROWS = 60;
+    private final String DATA_TYPE = "JSON";
+
+
+    @Override
+    public @NotNull CurrentWeather fetchCurrentWeather(@NotNull String depth1,
+                                                       @Nullable String depth2,
+                                                       @Nullable String depth3) {
+        var administrativeRegion = loadCoordinatesPort.getCoordinatesForAddress(depth1, depth2, depth3);
+
+        var weatherForecastResponse = fetchWeatherForecast(administrativeRegion);
+        var airPollutionResponse = fetchAirPollution(administrativeRegion);
+        var liveWeatherResponse = fetchLiveWeather(administrativeRegion);
+
+        return mapToDomainModel(weatherForecastResponse, airPollutionResponse, liveWeatherResponse);
+    }
+
+    private WeatherForecastApiResponse fetchWeatherForecast(AdministrativeRegion administrativeRegion) {
+        var forecastTime = getBaseTime(LocalDateTime.now());
+        return weatherForecastRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("serviceKey", "{serviceKey}")
+                        .queryParam("pageNo", PAGE_NO)
+                        .queryParam("numOfRows", NUM_OF_ROWS)
+                        .queryParam("dataType", DATA_TYPE)
+                        .queryParam("base_date", forecastTime.baseDate())
+                        .queryParam("base_time", forecastTime.baseTime())
+                        .queryParam("nx", administrativeRegion.latitudeDegree())
+                        .queryParam("ny", administrativeRegion.longitudeDegree())
+                        .build())
+                .retrieve()
+                .toEntity(WeatherForecastApiResponse.class)
+                .getBody();
+    }
+
+    private AirPollutionApiResponse fetchAirPollution(AdministrativeRegion administrativeRegion) {
+        // TODO 지역 이름 변환
+        Map<String, String> regionMap = Map.of(
+                "서울특별시", "서울",
+                "경기도", "경기"
+        );
+        return airPollutionRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("serviceKey", "{serviceKey}")
+                        .queryParam("pageNo", 1)
+                        .queryParam("numOfRows", 100)
+                        .queryParam("returnType", DATA_TYPE)
+                        .queryParam("sidoName", regionMap.get(administrativeRegion.regionDepth1()))
+                        .build())
+                .retrieve()
+                .toEntity(AirPollutionApiResponse.class)
+                .getBody();
+    }
+
+    private LiveWeatherApiResponse fetchLiveWeather(AdministrativeRegion administrativeRegion) {
+        String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+        return liveWeatherRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("serviceKey", "{serviceKey}")
+                        .queryParam("pageNo", 1)
+                        .queryParam("numOfRows", 100)
+                        .queryParam("dataType", DATA_TYPE)
+                        .queryParam("areaNo", administrativeRegion.adminCode())
+                        .queryParam("time", time)
+                        .build())
+                .retrieve()
+                .toEntity(LiveWeatherApiResponse.class)
+                .getBody();
+    }
+
+    private CurrentWeather mapToDomainModel(WeatherForecastApiResponse weatherForecastResponse,
+                                            AirPollutionApiResponse airPollutionResponse,
+                                            LiveWeatherApiResponse liveWeatherResponse) {
+
+        return new CurrentWeather(
+                WeatherCondition.from(
+                        weatherForecastResponse.getItemsByCategory("SKY").getFirst(),
+                        weatherForecastResponse.getItemsByCategory("PTY").getFirst(),
+                        weatherForecastResponse.getItemsByCategory("LGT").getFirst()
+                ),
+                HumidityLevel.fromValue(
+                        weatherForecastResponse.getItemsByCategory("REH").getFirst()
+                ),
+                RainfallIntensity.fromValue(
+                        weatherForecastResponse.getItemsByCategory("RN1").getFirst()
+                ),
+                AirQuality.Pm10.fromValue(
+                        airPollutionResponse.getPm10()
+                ),
+
+                AirQuality.Pm25.fromValue(
+                        airPollutionResponse.getPm25()
+                ),
+                UvIndex.fromValue(
+                        liveWeatherResponse.getCurrentUVIndex()
+                )
+        );
+    }
+
+
+    record BaseTime(String baseDate /*yyyyMMdd*/, String baseTime /*HHmm*/) {
+    }
+
+    /**
+     * 주어진 시간 기준으로 가장 최신 예보 시간을 계산
+     */
+    private BaseTime getBaseTime(LocalDateTime baseLocalDateTime) {
+        List<String> FORECAST_TIMES = List.of("0200", "0500", "0800", "1100", "1400", "1700", "2000", "2300");
+
+        String currentTime = baseLocalDateTime.format(DateTimeFormatter.ofPattern("HHmm"));
+        String today = baseLocalDateTime.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String yesterday = baseLocalDateTime.minusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        String latestTime = null;
+        for (String forecastTime : FORECAST_TIMES) {
+            if (forecastTime.compareTo(currentTime) <= 0) {
+                latestTime = forecastTime;
+            } else {
+                break;
+            }
+        }
+
+        if (latestTime == null) {
+            return new BaseTime(yesterday, FORECAST_TIMES.getLast());
+        }
+
+        return new BaseTime(today, latestTime);
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/api/WeatherRestClientConfig.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/api/WeatherRestClientConfig.java
@@ -1,0 +1,56 @@
+package com.example.hyh.weather.adapter.out.api;
+
+import com.example.hyh.global.ClientLoggerRequestInterceptor;
+import com.example.hyh.weather.adapter.out.api.properties.AirPollutionApiProperties;
+import com.example.hyh.weather.adapter.out.api.properties.LiveWeatherApiProperties;
+import com.example.hyh.weather.adapter.out.api.properties.WeatherForecastApiProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class WeatherRestClientConfig {
+
+    private final WeatherForecastApiProperties weatherForecastApiProperties;
+    private final AirPollutionApiProperties airPollutionApiProperties;
+    private final LiveWeatherApiProperties liveWeatherApiProperties;
+
+    @Bean
+    public RestClient weatherForecastRestClient(RestClient.Builder builder, ClientLoggerRequestInterceptor clientLoggerRequestInterceptor) {
+        DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory(weatherForecastApiProperties.getBaseUrl());
+        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+        uriBuilderFactory.setDefaultUriVariables(Map.of("serviceKey", weatherForecastApiProperties.getApiKey()));
+        return builder
+                .uriBuilderFactory(uriBuilderFactory)
+                .requestInterceptor(clientLoggerRequestInterceptor)
+                .build();
+    }
+
+    @Bean
+    public RestClient airPollutionRestClient(RestClient.Builder builder, ClientLoggerRequestInterceptor clientLoggerRequestInterceptor) {
+        DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory(airPollutionApiProperties.getBaseUrl());
+        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+        uriBuilderFactory.setDefaultUriVariables(Map.of("serviceKey", airPollutionApiProperties.getApiKey()));
+        return builder
+                .uriBuilderFactory(uriBuilderFactory)
+                .requestInterceptor(clientLoggerRequestInterceptor)
+                .build();
+    }
+
+    @Bean
+    public RestClient liveWeatherRestClient(RestClient.Builder builder, ClientLoggerRequestInterceptor clientLoggerRequestInterceptor) {
+        DefaultUriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory(liveWeatherApiProperties.getBaseUrl());
+        uriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+        uriBuilderFactory.setDefaultUriVariables(Map.of("serviceKey", liveWeatherApiProperties.getApiKey()));
+        return builder
+                .uriBuilderFactory(uriBuilderFactory)
+                .requestInterceptor(clientLoggerRequestInterceptor)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/api/properties/AirPollutionApiProperties.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/api/properties/AirPollutionApiProperties.java
@@ -1,0 +1,15 @@
+package com.example.hyh.weather.adapter.out.api.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "external.air-pollution.api")
+@Getter
+@Setter
+public class AirPollutionApiProperties {
+    private String baseUrl;
+    private String apiKey;
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/api/properties/LiveWeatherApiProperties.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/api/properties/LiveWeatherApiProperties.java
@@ -1,0 +1,15 @@
+package com.example.hyh.weather.adapter.out.api.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "external.live-weather.api")
+@Getter
+@Setter
+public class LiveWeatherApiProperties {
+    private String baseUrl;
+    private String apiKey;
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/api/properties/WeatherForecastApiProperties.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/api/properties/WeatherForecastApiProperties.java
@@ -1,0 +1,15 @@
+package com.example.hyh.weather.adapter.out.api.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "external.weather-forecast.api")
+@Getter
+@Setter
+public class WeatherForecastApiProperties {
+    private String baseUrl;
+    private String apiKey;
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/api/response/AirPollutionApiResponse.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/api/response/AirPollutionApiResponse.java
@@ -1,0 +1,63 @@
+package com.example.hyh.weather.adapter.out.api.response;
+
+import java.util.List;
+
+public record AirPollutionApiResponse(
+        Response<Item> response
+) {
+
+    public String getPm10() {
+        return response.body.items.getFirst().pm10Value;
+    }
+
+    public String getPm25() {
+        return response.body.items.getFirst().pm25Value;
+    }
+
+    public record Response<T>(
+            Header header,
+            Body<T> body
+    ) {
+    }
+
+    public record Header(
+            String resultCode,
+            String resultMsg
+    ) {
+    }
+
+    public record Body<T>(
+            int totalCount,
+            int pageNo,
+            int numOfRows,
+            List<T> items
+    ) {
+    }
+
+    public record Item(
+            String stationName,
+            String sidoName,
+            String dataTime,
+            String so2Value,
+            String coValue,
+            String o3Value,
+            String no2Value,
+            String pm10Value,
+            String pm25Value,
+            String khaiValue,
+            String so2Grade,
+            String coGrade,
+            String o3Grade,
+            String no2Grade,
+            String pm10Grade,
+            String pm25Grade,
+            String khaiGrade,
+            String so2Flag,
+            String coFlag,
+            String o3Flag,
+            String no2Flag,
+            String pm10Flag,
+            String pm25Flag
+    ) {
+    }
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/api/response/LiveWeatherApiResponse.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/api/response/LiveWeatherApiResponse.java
@@ -1,0 +1,72 @@
+package com.example.hyh.weather.adapter.out.api.response;
+
+import java.util.List;
+
+public record LiveWeatherApiResponse(
+        Response<Item> response
+) {
+
+    public String getCurrentUVIndex() {
+        return response.body.items.item.getFirst().h0;
+    }
+
+    public record Response<T>(
+            Header header,
+            Body<T> body
+    ) {
+    }
+
+    public record Header(
+            String resultCode,
+            String resultMsg
+    ) {
+    }
+
+    public record Body<T>(
+            String dataType,
+            Items<T> items,
+            int pageNo,
+            int numOfRows,
+            int totalCount
+    ) {
+    }
+
+    public record Items<T>(
+            List<T> item
+    ) {
+    }
+
+    public record Item(
+            String code,
+            String areaNo,
+            String date,
+            String h0,
+            String h3,
+            String h6,
+            String h9,
+            String h12,
+            String h15,
+            String h18,
+            String h21,
+            String h24,
+            String h27,
+            String h30,
+            String h33,
+            String h36,
+            String h39,
+            String h42,
+            String h45,
+            String h48,
+            String h51,
+            String h54,
+            String h57,
+            String h60,
+            String h63,
+            String h66,
+            String h69,
+            String h72,
+            String h75
+    ) {
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/api/response/WeatherForecastApiResponse.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/api/response/WeatherForecastApiResponse.java
@@ -1,0 +1,60 @@
+package com.example.hyh.weather.adapter.out.api.response;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Comparator;
+import java.util.List;
+
+
+public record WeatherForecastApiResponse(
+        Response<UltraSrtFcstItem> response
+) {
+
+    public List<String> getItemsByCategory(@NotNull String category) {
+        return response.body().items().item().stream()
+                .filter(item -> category.equals(item.category()))
+                .sorted(Comparator.comparing(item -> item.baseDate() + item.baseTime()))
+                .map(UltraSrtFcstItem::fcstValue)
+                .sorted()
+                .toList();
+    }
+
+    public record Response<T>(
+            Header header,
+            Body<T> body
+    ) {
+    }
+
+    public record Header(
+            String resultCode,
+            String resultMsg
+    ) {
+    }
+
+    public record Body<T>(
+            String dataType,
+            Items<T> items,
+            int pageNo,
+            int numOfRows,
+            int totalCount
+    ) {
+    }
+
+    public record Items<T>(
+            List<T> item
+    ) {
+    }
+
+    public record UltraSrtFcstItem(
+            String baseDate,
+            String baseTime,
+            String category,
+            String fcstDate,
+            String fcstTime,
+            String fcstValue,
+            int nx,
+            int ny
+    ) {
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/persistence/jpa/LoadCoordinatesJpaAdapter.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/persistence/jpa/LoadCoordinatesJpaAdapter.java
@@ -1,0 +1,43 @@
+package com.example.hyh.weather.adapter.out.persistence.jpa;
+
+import com.example.hyh.weather.adapter.out.persistence.jpa.entity.AdministrativeRegionJpaEntity;
+import com.example.hyh.weather.adapter.out.persistence.jpa.repository.AdministrativeRegionJpaRepository;
+import com.example.hyh.weather.application.port.out.LoadCoordinatesPort;
+import com.example.hyh.weather.domain.AdministrativeRegion;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoadCoordinatesJpaAdapter implements LoadCoordinatesPort {
+
+    private final AdministrativeRegionJpaRepository repository;
+
+    @Override
+    public AdministrativeRegion getCoordinatesForAddress(String depth1, String depth2, String depth3) {
+        return repository.findByRegionDepth1AndRegionDepth2AndRegionDepth3(depth1, depth2, depth3)
+                .map(this::mapToDomain)
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 주소르 찾을 수 없습니다. %s %s %s".formatted(depth1, depth2, depth3)));
+    }
+
+    private AdministrativeRegion mapToDomain(AdministrativeRegionJpaEntity entity) {
+        return new AdministrativeRegion(
+                entity.getCategory(),
+                entity.getAdminCode(),
+                entity.getRegionDepth1(),
+                entity.getRegionDepth2(),
+                entity.getRegionDepth3(),
+                entity.getGridX(),
+                entity.getGridY(),
+                entity.getLongitudeDegree(),
+                entity.getLongitudeMinute(),
+                entity.getLongitudeSecond(),
+                entity.getLatitudeDegree(),
+                entity.getLatitudeMinute(),
+                entity.getLatitudeSecond(),
+                entity.getLongitudeDecimal(),
+                entity.getLatitudeDecimal()
+        );
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/persistence/jpa/entity/AdministrativeRegionJpaEntity.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/persistence/jpa/entity/AdministrativeRegionJpaEntity.java
@@ -1,0 +1,65 @@
+package com.example.hyh.weather.adapter.out.persistence.jpa.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "administrative_region")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdministrativeRegionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "category", nullable = false, length = 10, insertable = false, updatable = false)
+    private String category;
+
+    @Column(name = "admin_code", nullable = false, length = 20, insertable = false, updatable = false)
+    private String adminCode;
+
+    @Column(name = "region_depth1", nullable = false, length = 50, insertable = false, updatable = false)
+    private String regionDepth1;
+
+    @Column(name = "region_depth2", length = 50, insertable = false, updatable = false)
+    private String regionDepth2;
+
+    @Column(name = "region_depth3", length = 50, insertable = false, updatable = false)
+    private String regionDepth3;
+
+    @Column(name = "grid_x", nullable = false, insertable = false, updatable = false)
+    private int gridX;
+
+    @Column(name = "grid_y", nullable = false, insertable = false, updatable = false)
+    private int gridY;
+
+    @Column(name = "longitude_degree", nullable = false, insertable = false, updatable = false)
+    private int longitudeDegree;
+
+    @Column(name = "longitude_minute", nullable = false, insertable = false, updatable = false)
+    private int longitudeMinute;
+
+    @Column(name = "longitude_second", nullable = false, precision = 10, scale = 2, insertable = false, updatable = false)
+    private BigDecimal longitudeSecond;
+
+    @Column(name = "latitude_degree", nullable = false, insertable = false, updatable = false)
+    private int latitudeDegree;
+
+    @Column(name = "latitude_minute", nullable = false, insertable = false, updatable = false)
+    private int latitudeMinute;
+
+    @Column(name = "latitude_second", nullable = false, precision = 10, scale = 2, insertable = false, updatable = false)
+    private BigDecimal latitudeSecond;
+
+    @Column(name = "longitude_decimal", nullable = false, precision = 15, scale = 12, insertable = false, updatable = false)
+    private BigDecimal longitudeDecimal;
+
+    @Column(name = "latitude_decimal", nullable = false, precision = 15, scale = 12, insertable = false, updatable = false)
+    private BigDecimal latitudeDecimal;
+
+}

--- a/src/main/java/com/example/hyh/weather/adapter/out/persistence/jpa/repository/AdministrativeRegionJpaRepository.java
+++ b/src/main/java/com/example/hyh/weather/adapter/out/persistence/jpa/repository/AdministrativeRegionJpaRepository.java
@@ -1,0 +1,12 @@
+package com.example.hyh.weather.adapter.out.persistence.jpa.repository;
+
+import com.example.hyh.weather.adapter.out.persistence.jpa.entity.AdministrativeRegionJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdministrativeRegionJpaRepository extends JpaRepository<AdministrativeRegionJpaEntity, Long> {
+
+    Optional<AdministrativeRegionJpaEntity> findByRegionDepth1AndRegionDepth2AndRegionDepth3(String regionDepth1, String regionDepth2, String regionDepth3);
+
+}

--- a/src/main/java/com/example/hyh/weather/application/WeatherService.java
+++ b/src/main/java/com/example/hyh/weather/application/WeatherService.java
@@ -1,0 +1,22 @@
+package com.example.hyh.weather.application;
+
+import com.example.hyh.weather.application.port.in.GetCurrentWeatherCommand;
+import com.example.hyh.weather.application.port.in.GetCurrentWeatherUseCase;
+import com.example.hyh.weather.application.port.out.FetchCurrentWeatherPort;
+import com.example.hyh.weather.domain.CurrentWeather;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+class WeatherService implements GetCurrentWeatherUseCase {
+
+    private final FetchCurrentWeatherPort fetchCurrentWeatherPort;
+
+    @Override
+    public @NotNull CurrentWeather getCurrentWeather(@NotNull GetCurrentWeatherCommand command) {
+        return fetchCurrentWeatherPort.fetchCurrentWeather(command.depth1(), command.depth2(), command.depth3());
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/application/port/in/GetCurrentWeatherCommand.java
+++ b/src/main/java/com/example/hyh/weather/application/port/in/GetCurrentWeatherCommand.java
@@ -1,0 +1,8 @@
+package com.example.hyh.weather.application.port.in;
+
+public record GetCurrentWeatherCommand(
+        String depth1,
+        String depth2,
+        String depth3
+) {
+}

--- a/src/main/java/com/example/hyh/weather/application/port/in/GetCurrentWeatherUseCase.java
+++ b/src/main/java/com/example/hyh/weather/application/port/in/GetCurrentWeatherUseCase.java
@@ -1,0 +1,10 @@
+package com.example.hyh.weather.application.port.in;
+
+import com.example.hyh.weather.domain.CurrentWeather;
+import org.jetbrains.annotations.NotNull;
+
+public interface GetCurrentWeatherUseCase {
+
+    @NotNull CurrentWeather getCurrentWeather(@NotNull GetCurrentWeatherCommand command);
+
+}

--- a/src/main/java/com/example/hyh/weather/application/port/out/FetchCurrentWeatherPort.java
+++ b/src/main/java/com/example/hyh/weather/application/port/out/FetchCurrentWeatherPort.java
@@ -1,0 +1,13 @@
+package com.example.hyh.weather.application.port.out;
+
+import com.example.hyh.weather.domain.CurrentWeather;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface FetchCurrentWeatherPort {
+
+    @NotNull CurrentWeather fetchCurrentWeather(@NotNull String depth1,
+                                                @Nullable String depth2,
+                                                @Nullable String depth3);
+
+}

--- a/src/main/java/com/example/hyh/weather/application/port/out/LoadCoordinatesPort.java
+++ b/src/main/java/com/example/hyh/weather/application/port/out/LoadCoordinatesPort.java
@@ -1,0 +1,9 @@
+package com.example.hyh.weather.application.port.out;
+
+import com.example.hyh.weather.domain.AdministrativeRegion;
+
+public interface LoadCoordinatesPort {
+
+    AdministrativeRegion getCoordinatesForAddress(String depth1, String depth2, String depth3);
+
+}

--- a/src/main/java/com/example/hyh/weather/domain/AdministrativeRegion.java
+++ b/src/main/java/com/example/hyh/weather/domain/AdministrativeRegion.java
@@ -1,0 +1,22 @@
+package com.example.hyh.weather.domain;
+
+import java.math.BigDecimal;
+
+public record AdministrativeRegion(
+        String category,
+        String adminCode,
+        String regionDepth1,
+        String regionDepth2,
+        String regionDepth3,
+        int gridX,
+        int gridY,
+        int longitudeDegree,
+        int longitudeMinute,
+        BigDecimal longitudeSecond,
+        int latitudeDegree,
+        int latitudeMinute,
+        BigDecimal latitudeSecond,
+        BigDecimal longitudeDecimal,
+        BigDecimal latitudeDecimal
+) {
+}

--- a/src/main/java/com/example/hyh/weather/domain/AirQuality.java
+++ b/src/main/java/com/example/hyh/weather/domain/AirQuality.java
@@ -1,0 +1,86 @@
+package com.example.hyh.weather.domain;
+
+import com.example.hyh.global.Utils;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Slf4j
+public class AirQuality {
+
+    public enum Pm10 {
+        Good("좋음", 0, 30),
+        Moderate("보통", 31, 80),
+        Bad("나쁨", 81, 150),
+        VeryBad("매우 나쁨", 151, Integer.MAX_VALUE),
+        Invalid("-", Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+        @Getter
+        private final String displayName;
+        private final int minValue;
+        private final int maxValue;
+
+        Pm10(String displayName, int minValue, int maxValue) {
+            this.displayName = displayName;
+            this.minValue = minValue;
+            this.maxValue = maxValue;
+        }
+
+        public static @NotNull Pm10 fromValue(int value) {
+            for (Pm10 quality : values()) {
+                if (value >= quality.minValue && value <= quality.maxValue) {
+                    return quality;
+                }
+            }
+            log.info("유효하지 않은 미세먼지(pm10) 수치: {}", value);
+            return Invalid;
+        }
+
+        public static @NotNull Pm10 fromValue(@Nullable String stringValue) {
+            if (!Utils.isNumeric(stringValue)) {
+                log.info("수치 형식 오류: {}", stringValue);
+                return Invalid;
+            }
+            return fromValue(Integer.parseInt(stringValue));
+        }
+    }
+
+    public enum Pm25 {
+        Good("좋음", 0, 15),
+        Moderate("보통", 16, 35),
+        Bad("나쁨", 36, 75),
+        VeryBad("매우 나쁨", 75, Integer.MAX_VALUE),
+        Invalid("-", Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+        @Getter
+        private final String displayName;
+        private final int minValue;
+        private final int maxValue;
+
+        Pm25(String displayName, int minValue, int maxValue) {
+            this.displayName = displayName;
+            this.minValue = minValue;
+            this.maxValue = maxValue;
+        }
+
+        public static @NotNull Pm25 fromValue(int value) {
+            for (Pm25 quality : values()) {
+                if (value >= quality.minValue && value <= quality.maxValue) {
+                    return quality;
+                }
+            }
+            log.info("유효하지 않은 미세먼지(pm2.5) 수치: {}", value);
+            return Invalid;
+        }
+
+        public static @NotNull Pm25 fromValue(@Nullable String stringValue) {
+            if (!Utils.isNumeric(stringValue)) {
+                return Invalid;
+            }
+            assert stringValue != null;
+            return fromValue(Integer.parseInt(stringValue));
+        }
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/domain/CurrentWeather.java
+++ b/src/main/java/com/example/hyh/weather/domain/CurrentWeather.java
@@ -1,0 +1,11 @@
+package com.example.hyh.weather.domain;
+
+public record CurrentWeather(
+        WeatherCondition weatherCondition,
+        HumidityLevel humidityLevel,
+        RainfallIntensity rainfallIntensity,
+        AirQuality.Pm10 airQualityPm10,
+        AirQuality.Pm25 airQualityPm25,
+        UvIndex uvIndex
+) {
+}

--- a/src/main/java/com/example/hyh/weather/domain/HumidityLevel.java
+++ b/src/main/java/com/example/hyh/weather/domain/HumidityLevel.java
@@ -1,0 +1,44 @@
+package com.example.hyh.weather.domain;
+
+import com.example.hyh.global.Utils;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public enum HumidityLevel {
+    Dry("건조", 0, 30),
+    Comfortable("쾌적", 31, 60),
+    SomewhatHumid("다소 습함", 61, 80),
+    VeryHumid("매우 습함", 81, 100),
+    Invalid("-", Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+    @Getter
+    private final String displayName;
+    private final int minValue;
+    private final int maxValue;
+
+    HumidityLevel(String displayName, int minValue, int maxValue) {
+        this.displayName = displayName;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+    }
+
+    public static HumidityLevel fromValue(int value) {
+        for (HumidityLevel level : values()) {
+            if (value >= level.minValue && value <= level.maxValue) {
+                return level;
+            }
+        }
+        log.info("유효하지 않은 습도 수치: {}", value);
+        return Invalid;
+    }
+
+    public static HumidityLevel fromValue(String value) {
+        if (!Utils.isNumeric(value)) {
+            log.info("수치 형식 오류: {}", value);
+            return Invalid;
+        }
+        return fromValue(Integer.parseInt(value));
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/domain/Location.java
+++ b/src/main/java/com/example/hyh/weather/domain/Location.java
@@ -1,0 +1,22 @@
+package com.example.hyh.weather.domain;
+
+import org.springframework.util.StringUtils;
+
+public record Location(
+        String city,
+        String dong
+) {
+    public Location {
+        if (!StringUtils.hasText(city)) {
+            throw new IllegalArgumentException("시 이름이 null 또는 빈 문자열입니다.");
+        }
+        if (!StringUtils.hasText(dong)) {
+            throw new IllegalArgumentException("동 이름이 null 또는 빈 문자열입니다.");
+        }
+    }
+
+    public String getFullAddress() {
+        return String.format("%s %s ", city, dong);
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/domain/RainfallIntensity.java
+++ b/src/main/java/com/example/hyh/weather/domain/RainfallIntensity.java
@@ -1,0 +1,49 @@
+package com.example.hyh.weather.domain;
+
+import com.example.hyh.global.Utils;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public enum RainfallIntensity {
+    NoRain("비 없음", 0, 0),
+    Moderate("보통 비", 0, 0.9),
+    Heavy("강한 비", 1, 2.9),
+    VeryHeavy("매우 강한 비", 3, Double.MAX_VALUE),
+    Invalid("-", Double.MIN_VALUE, Double.MIN_VALUE);
+
+    @Getter
+    private final String displayName;
+    private final double minValue;
+    private final double maxValue;
+
+    RainfallIntensity(String displayName, double minValue, double maxValue) {
+        this.displayName = displayName;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+    }
+
+    public static RainfallIntensity fromValue(double value) {
+        for (RainfallIntensity intensity : values()) {
+            if (value >= intensity.minValue && value <= intensity.maxValue) {
+                return intensity;
+            }
+        }
+        log.info("유효하지 않은 강우량: {}", value);
+        return Invalid;
+    }
+
+    public static RainfallIntensity fromValue(String value) {
+        if ("강수없음".equals(value)) {
+            return NoRain;
+        }
+
+        if (!Utils.isNumeric(value)) {
+            log.info("수치 형식 오류: {}", value);
+            return Invalid;
+        }
+
+        return fromValue(Double.parseDouble(value));
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/domain/UvIndex.java
+++ b/src/main/java/com/example/hyh/weather/domain/UvIndex.java
@@ -1,0 +1,44 @@
+package com.example.hyh.weather.domain;
+
+import com.example.hyh.global.Utils;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public enum UvIndex {
+    Low("좋음", 0, 2),
+    Moderate("보통", 3, 5),
+    High("높음", 6, 7),
+    VeryHigh("매우 높음", 8, Integer.MAX_VALUE),
+    Invalid("-", Integer.MIN_VALUE, Integer.MIN_VALUE);
+
+    @Getter
+    private final String displayName;
+    private final int minValue;
+    private final int maxValue;
+
+    UvIndex(String displayName, int minValue, int maxValue) {
+        this.displayName = displayName;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+    }
+
+    public static UvIndex fromValue(int value) {
+        for (UvIndex index : values()) {
+            if (value >= index.minValue && value <= index.maxValue) {
+                return index;
+            }
+        }
+        log.info("유효하지 않은 자외선 지수: {}", value);
+        return Invalid;
+    }
+
+    public static UvIndex fromValue(String value) {
+        if (!Utils.isNumeric(value)) {
+            log.info("수치 형식 오류: {}", value);
+            return Invalid;
+        }
+        return fromValue(Integer.parseInt(value));
+    }
+
+}

--- a/src/main/java/com/example/hyh/weather/domain/WeatherCondition.java
+++ b/src/main/java/com/example/hyh/weather/domain/WeatherCondition.java
@@ -1,0 +1,50 @@
+package com.example.hyh.weather.domain;
+
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+public enum WeatherCondition {
+    ClearDay("맑음(낮)"),
+    ClearNight("맑음(밤)"),
+    PartlyCloudyDay("구름(낮)"),
+    PartlyCloudyNight("구름(밤)"),
+    Cloudy("흐림"),
+    Rain("비"),
+    Snow("눈"),
+    Thunderstorm("천둥번개"),
+    Invalid("-");
+
+    private final static Set<String> RAIN_CONDITIONS = Set.of("1", "4", "5");
+    private final static Set<String> SNOW_CONDITIONS = Set.of("3", "7");
+
+
+    @Getter
+    private final String displayName;
+
+    WeatherCondition(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public static @NotNull WeatherCondition from(@Nullable String sky,
+                                                 @Nullable String pty,
+                                                 @Nullable String lightning) {
+        if ("1".equals(sky) && "0".equals(pty)) {
+            return WeatherCondition.ClearDay;
+        } else if ("3".equals(sky) && "0".equals(pty)) {
+            return WeatherCondition.PartlyCloudyDay;
+        } else if ("4".equals(sky) && "0".equals(pty)) {
+            return WeatherCondition.Cloudy;
+        } else if (RAIN_CONDITIONS.contains(pty)) {
+            return WeatherCondition.Rain;
+        } else if (SNOW_CONDITIONS.contains(pty)) {
+            return WeatherCondition.Snow;
+        } else if ("1".equals(lightning)) {
+            return WeatherCondition.Thunderstorm;
+        }
+        return WeatherCondition.Invalid;
+    }
+
+}


### PR DESCRIPTION
- 헥사고날 아키텍처로 구성 : 개선 필요
- API 요청은 주소를 사용한다.
  - 행정구역 정보를 DB에 저장 후 필요한 위도/경도, 행정구역 번호를 조회해 외부 API 호출에 사용

---

- 상세 내용은 컨플루언스 문서에 작성했습니다.